### PR TITLE
Permitir herencia en ApiRest

### DIFF
--- a/src/ApiRest.php
+++ b/src/ApiRest.php
@@ -339,7 +339,7 @@ class ApiRest
         return $this->executeRequest('/v1/payments/' . $order . '/refund', $params);
     }
 
-    private function executeRequest($endpoint, $params)
+    protected function executeRequest($endpoint, $params)
     {
         $jsonParams = json_encode($params);
 


### PR DESCRIPTION
Me encuentro que necesito llamar el método addUser pero usando los datos de la tarjeta en lugar del `jetToken`. Al querer hacer herencia para crear mi propio método addUser veo que el método `executeRequest` está bloqueado al ser privado.

Con este pequeño cambio tendremos más libertad para ampliar la funcionalidad que nos brinda la base que habéis preparado.