### PR TITLE
Asegurarse de que es una IPv4. En caso contrario poner la IPv4 manual…

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -5,6 +5,9 @@ namespace Paycomet\Bankstore;
 use SoapClient;
 use SoapFault;
 use stdClass;
+use function filter_var;
+use const FILTER_FLAG_IPV4;
+use const FILTER_VALIDATE_IP;
 
 /**
  * API de PAYCOMET para PHP. Métodos BankStore IFRAME/FULLSCREEN/XML/JET
@@ -1736,7 +1739,7 @@ class Client
      * @return string Debe de ser la ip del cliente. En su defecto, devuelve la ip del servidor.
      * @version 1.3.0 2019-09-22
      */
-    public function GetClientIp()
+  public function GetClientIp()
     {
         $ipAddress = '';
         if (isset($_SERVER['REMOTE_ADDR'])) {
@@ -1753,6 +1756,9 @@ class Client
             $ipAddress = $_SERVER['HTTP_CLIENT_IP'];
         } else {
             $ipAddress = $_SERVER['SERVER_ADDR'];  // Server IP por defecto
+        }
+        if(!filter_var($ipAddress, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+            $ipAddress = "XXX.XXX.XXX.XXX";  // Server IP por defecto
         }
         return $ipAddress;
     }


### PR DESCRIPTION
Asegurarse de que es una IPv4. Paycomet no soporta IPv6 y no siempre se puede garantizar que un server moderno devuelva una ipv4. De hecho en nuestro caso sucede que en la mayoría de las transacciones se hacen identificando con ipv6.
Queda pendiente obtener la IPv4 del server, en caso de que la tenga.